### PR TITLE
Add Travis CI builds for more recent DMD releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ sudo: false
 # LLVM ERROR: Broken function found, compilation aborted!
 
 d:
-  - dmd-2.082.0
+  - dmd-2.085.1
+  - dmd-2.084.1
+  - dmd-2.083.1
+  - dmd-2.082.1
   - dmd-2.081.1
   - dmd-2.080.1
   - dmd-2.079.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ d:
   - ldc-1.9.0
   - dmd-beta
 
+script:
+  - dub test --compiler=${DC}
+  - dub upgrade && dub test --compiler=${DC}
+
 matrix:
   allow_failures:
     - d: dmd-beta


### PR DESCRIPTION
The most recent tested DMD is very outdated compared to the most recent release (2.090.0).  This patch adds builds for all the most recent patch releases of DMD, up to the latest.

N.B. I anticipate this to fail for DMD >= 2.086 going by my own local testing.  This PR is created to illustrate the problem: I'll write up follow-up issues to try to identify the core problems.