### PR TITLE
Fix support for more recent taggedalgebraic versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ sudo: false
 # LLVM ERROR: Broken function found, compilation aborted!
 
 d:
+  - dmd-2.090.0
+  - dmd-2.088.1
+  - dmd-2.087.1
+  - dmd-2.086.1
   - dmd-2.085.1
   - dmd-2.084.1
   - dmd-2.083.1

--- a/source/stdx/data/json/value.d
+++ b/source/stdx/data/json/value.d
@@ -99,6 +99,30 @@ struct JSONValue
       * Use `.hasType!T` or `.typeID` for that purpose.
       */
     ref inout(T) get(T)() inout { return .get!T(payload); }
+
+    /**
+      * Enables equality comparisons.
+      *
+      * Note that the location is considered token metadata and thus does not
+      * affect the comparison.
+      */
+    bool opEquals(T)(auto ref inout(T) other) inout
+    {
+        import std.traits : Unqual;
+
+        static if (is(Unqual!T == typeof(null)))
+        {
+            return this.isNull;
+        }
+        else static if (is(Unqual!T == JSONValue))
+        {
+            return this.payload == other.payload;
+        }
+        else
+        {
+            return this.payload == other;
+        }
+    }
 }
 
 /// Shows the basic construction and operations on JSON values.
@@ -149,9 +173,8 @@ unittest
     assert(longval == 56.0);
     assert(longval == longval);
 
-    // FIXME: commented out test fails with taggedalgebraic v0.11.x
     assert(intval + longval == 78);
-    // assert(intval + longval == intval + longval);
+    assert(intval + longval == intval + longval);
 
     JSONValue floatval = 32.0f;
     assert(floatval.hasType!double());
@@ -164,28 +187,26 @@ unittest
     assert(doubleval == 63.5);
     assert(doubleval == doubleval);
 
-    // FIXME: commented out tests fail with taggedalgebraic v0.11.x
     assert(floatval + doubleval == 95.5);
-    // assert(floatval + doubleval == floatval + doubleval);
+    assert(floatval + doubleval == floatval + doubleval);
     assert(intval + longval + floatval + doubleval == 173.5);
-    // assert(intval + longval + floatval + doubleval ==
-    //        intval + longval + floatval + doubleval);
+    assert(intval + longval + floatval + doubleval ==
+           intval + longval + floatval + doubleval);
 
     JSONValue strval = "Hello!";
     assert(strval.hasType!string());
     assert(strval == "Hello!");
     assert(strval == strval);
 
-    // FIXME: commented out tests fail <https://github.com/dlang-community/std_data_json/issues/48>
     auto arrval = JSONValue([floatval, doubleval]);
     assert(arrval.hasType!(JSONValue[])());
-    // assert(arrval == [floatval, doubleval]);
+    assert(arrval == [floatval, doubleval]);
     assert(arrval == [32.0, 63.5]);
     assert(arrval[0] == floatval);
     assert(arrval[0] == 32.0);
     assert(arrval[1] == doubleval);
     assert(arrval[1] == 63.5);
-    // assert(arrval == arrval);
+    assert(arrval == arrval);
 
     auto objval = JSONValue(["f": floatval, "d": doubleval]);
     assert(objval.hasType!(JSONValue[string])());

--- a/source/stdx/data/json/value.d
+++ b/source/stdx/data/json/value.d
@@ -124,6 +124,78 @@ unittest
     assert(d["b"] == b);
 }
 
+// Unittests for JSONValue equality comparisons
+unittest
+{
+    JSONValue nullval = null;
+    assert(nullval.hasType!(typeof(null))());
+    assert(nullval == null);
+    assert(nullval == nullval);
+
+    JSONValue boolval = true;
+    assert(boolval.hasType!bool());
+    assert(boolval == true);
+    assert(boolval == boolval);
+
+    JSONValue intval = 22;
+    assert(intval.hasType!long());
+    assert(intval == 22);
+    assert(intval == 22.0);
+    assert(intval == intval);
+
+    JSONValue longval = 56L;
+    assert(longval.hasType!long());
+    assert(longval == 56);
+    assert(longval == 56.0);
+    assert(longval == longval);
+
+    // FIXME: commented out test fails with taggedalgebraic v0.11.x
+    assert(intval + longval == 78);
+    // assert(intval + longval == intval + longval);
+
+    JSONValue floatval = 32.0f;
+    assert(floatval.hasType!double());
+    assert(floatval == 32);
+    assert(floatval == 32.0);
+    assert(floatval == floatval);
+
+    JSONValue doubleval = 63.5;
+    assert(doubleval.hasType!double());
+    assert(doubleval == 63.5);
+    assert(doubleval == doubleval);
+
+    // FIXME: commented out tests fail with taggedalgebraic v0.11.x
+    assert(floatval + doubleval == 95.5);
+    // assert(floatval + doubleval == floatval + doubleval);
+    assert(intval + longval + floatval + doubleval == 173.5);
+    // assert(intval + longval + floatval + doubleval ==
+    //        intval + longval + floatval + doubleval);
+
+    JSONValue strval = "Hello!";
+    assert(strval.hasType!string());
+    assert(strval == "Hello!");
+    assert(strval == strval);
+
+    // FIXME: commented out tests fail <https://github.com/dlang-community/std_data_json/issues/48>
+    auto arrval = JSONValue([floatval, doubleval]);
+    assert(arrval.hasType!(JSONValue[])());
+    // assert(arrval == [floatval, doubleval]);
+    assert(arrval == [32.0, 63.5]);
+    assert(arrval[0] == floatval);
+    assert(arrval[0] == 32.0);
+    assert(arrval[1] == doubleval);
+    assert(arrval[1] == 63.5);
+    // assert(arrval == arrval);
+
+    auto objval = JSONValue(["f": floatval, "d": doubleval]);
+    assert(objval.hasType!(JSONValue[string])());
+    assert(objval["f"] == floatval);
+    assert(objval["f"] == 32.0);
+    assert(objval["d"] == doubleval);
+    assert(objval["d"] == 63.5);
+    assert(objval == objval);
+}
+
 
 /// Proxy structure that stores BigInt as a pointer to save space in JSONValue
 static struct WrappedBigInt {


### PR DESCRIPTION
`JSONValue` relies on an `alias this` to inherit equality comparison from its payload.  As of DMD 2.086.0 this will no longer work, as the auto-generated struct `opEquals` will now be preferred over the aliased one: https://dlang.org/changelog/2.086.0.html#alias_this_opEquals

For taggedalgebraic v0.10.x this appears to have no impact, but for v0.11.0+ this will break code (see https://github.com/dlang-community/std_data_json/issues/44#issuecomment-571111135 for details).

These patches fix the issue by introducing an explicit `JSONValue.opEquals`.  This should behave in an identical way to the old `alias this`-based equality comparison, with the exception of fixing some array equality comparison bugs described in https://github.com/dlang-community/std_data_json/issues/48.

Fixes https://github.com/dlang-community/std_data_json/issues/44.
Fixes https://github.com/dlang-community/std_data_json/issues/48.