### PR TITLE
Remove dub.selections.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ docs.json
 __dummy.html
 *.[ao]
 *.obj
+
+# Since this is a library, ignore `dub.selections.json`
+dub.selections.json

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"taggedalgebraic": "0.10.9"
-	}
-}


### PR DESCRIPTION
```
For applications, it makes sense to have dub.selections.json to lock in what version to use.
However, for a library like std_data_json, we can just use the version in dub.json.
```

@s-ludwig : My goal here is essentially to support the latest taggedalgebraic (0.10.18).
I think this makes sense, but if you prefer, I can simply turn this into a dependency upgrade.