### PR TITLE
Remove pointless `@disable this(this)`.

### DIFF
--- a/source/stdx/data/json/parser.d
+++ b/source/stdx/data/json/parser.d
@@ -1024,8 +1024,6 @@ auto readArray(R)(ref R nodes) @system if (isJSONParserNodeInputRange!R)
         R* nodes;
         size_t depth = 0;
 
-        @disable this(this);
-
         @property bool empty() { return !nodes || nodes.empty; }
 
         @property ref const(typeof(nodes.front)) front() { return nodes.front; }


### PR DESCRIPTION
Why is this there? I don't see any reason to make array ranges a pure input range. It doesn't have `save` either, not that anyone uses that.

Far as I can tell, `VR` supports repeated iteration just fine.